### PR TITLE
Feat: make the shape insettable

### DIFF
--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct SmoothRoundedRectangle: Shape {
+public struct SmoothRoundedRectangle: InsettableShape {
 
     let topLeftCorner: CornerAttributes
     let topRightCorner: CornerAttributes

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 public struct SmoothRoundedRectangle: Shape {
-    
+
     let topLeftCorner: CornerAttributes
     let topRightCorner: CornerAttributes
     let bottomLeftCorner: CornerAttributes
     let bottomRightCorner: CornerAttributes
-    
+
+    var insetAmount = 0.0
+
     // MARK: - Initializers
     
     /// Standard all corners with optional smoothness and same radius
@@ -50,7 +52,9 @@ public struct SmoothRoundedRectangle: Shape {
     // MARK: - Path
     
     public func path(in rect: CGRect) -> Path {
-        let normRect = normalizeCorners(rect, rectAttr: SmoothRectangleAttributes(
+        let insetRect = rect.insetBy(dx: insetAmount, dy: insetAmount)
+
+        let normRect = normalizeCorners(insetRect, rectAttr: SmoothRectangleAttributes(
             topRight: topRightCorner,
             bottomRight: bottomRightCorner,
             bottomLeft: bottomLeftCorner,
@@ -60,11 +64,12 @@ public struct SmoothRoundedRectangle: Shape {
         var path = Path()
         path.move(to: CGPoint(x: normRect.topLeft.segmentLength, y: 0))
         
-        drawCornerPath(&path, in: rect, cornerAttributes: normRect.topRight, corner: .topRight)
-        drawCornerPath(&path, in: rect, cornerAttributes: normRect.bottomRight, corner: .bottomRight)
-        drawCornerPath(&path, in: rect, cornerAttributes: normRect.bottomLeft, corner: .bottomLeft)
-        drawCornerPath(&path, in: rect, cornerAttributes: normRect.topLeft, corner: .topLeft)
+        drawCornerPath(&path, in: insetRect, cornerAttributes: normRect.topRight, corner: .topRight)
+        drawCornerPath(&path, in: insetRect, cornerAttributes: normRect.bottomRight, corner: .bottomRight)
+        drawCornerPath(&path, in: insetRect, cornerAttributes: normRect.bottomLeft, corner: .bottomLeft)
+        drawCornerPath(&path, in: insetRect, cornerAttributes: normRect.topLeft, corner: .topLeft)
         path.closeSubpath()
-        return path
+
+        return path.offsetBy(dx: insetAmount, dy: insetAmount)
     }
 }

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -72,4 +72,12 @@ public struct SmoothRoundedRectangle: Shape {
 
         return path.offsetBy(dx: insetAmount, dy: insetAmount)
     }
+
+    // MARK: - Insettable
+
+    public func inset(by amount: CGFloat) -> some InsettableShape {
+        var shape = self
+        shape.insetAmount += amount
+        return shape
+    }
 }


### PR DESCRIPTION
This PR unlocks several new possibilities, with one of the most notable being the ability for users to apply the native `.strokeBorder` modifier, which draws borders **inside** the shape rather than centered.

with `.strokeBorder` modifier
![Screenshot 2024-11-08 at 2 36 06 PM](https://github.com/user-attachments/assets/c2049494-d86a-40af-ac0d-dfd7e675bffb)

with `.stroke` modifier
![Screenshot 2024-11-08 at 2 36 31 PM](https://github.com/user-attachments/assets/a01ab9de-68fd-4252-b36c-cb72bf9be130)
