### PR TITLE
feat: add a dedicated preview to showcase the new layout directed api

### DIFF
--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -13,9 +13,9 @@ import SmoothRoundedRectangle
 
 	let smoothUnevenShape = SmoothRoundedRectangle(
 		topLeading: 0,
-		topTrailing: radius,
-		bottomTrailing: radius,
 		bottomLeading: 0,
+		bottomTrailing: radius,
+		topTrailing: radius,
 		smoothness: .custom(100)
 	)
 

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -7,8 +7,11 @@ import SmoothRoundedRectangle
 	@Previewable @State var smoothness: Double = 50
 
 	let unevenShape = UnevenRoundedRectangle(
+		topLeadingRadius: 0,
+		bottomLeadingRadius: 0,
 		bottomTrailingRadius: radius,
-		topTrailingRadius: radius
+		topTrailingRadius: radius,
+		style: .continuous
 	)
 
 	let smoothUnevenShape = SmoothRoundedRectangle(

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -15,10 +15,10 @@ import SmoothRoundedRectangle
 	)
 
 	let smoothUnevenShape = SmoothRoundedRectangle(
-		topLeading: 0,
-		bottomLeading: 0,
-		bottomTrailing: radius,
-		topTrailing: radius,
+		topLeadingRadius: 0,
+		bottomLeadingRadius: 0,
+		bottomTrailingRadius: radius,
+		topTrailingRadius: radius,
 		smoothness: .custom(100)
 	)
 

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import SmoothRoundedRectangle
+
+@available(iOS 16, *)
+#Preview {
+	@Previewable @State var radius: Double = 64
+	@Previewable @State var smoothness: Double = 50
+
+	let unevenShape = UnevenRoundedRectangle(
+		bottomTrailingRadius: radius,
+		topTrailingRadius: radius
+	)
+
+	let smoothUnevenShape = SmoothRoundedRectangle(
+		topLeading: 0,
+		topTrailing: radius,
+		bottomTrailing: radius,
+		bottomLeading: 0,
+		smoothness: .custom(100)
+	)
+
+	VStack {
+		ForEach(LayoutDirection.allCases, id: \.self) { direction in
+			unevenShape
+				.fill(.red)
+				.overlay {
+					smoothUnevenShape
+						.foregroundStyle(.indigo)
+				}
+				.environment(\.layoutDirection, direction)
+				.overlay {
+					Text(String(describing: direction))
+				}
+		}
+
+		VStack(alignment: .leading, spacing: 0) {
+			HStack {
+				Text("Radius")
+				Spacer()
+				Text(radius, format: .number.precision(.fractionLength(0)))
+					.monospacedDigit()
+			}
+			Slider(value: $radius, in: 0...128)
+
+			Divider().frame(height: 64)
+
+			HStack {
+				Text("Smoothness")
+				Spacer()
+				Text(smoothness, format: .number.precision(.fractionLength(0)))
+					.monospacedDigit()
+			}
+			Slider(value: $smoothness, in: 0...50)
+		}
+	}
+	.padding()
+	.preferredColorScheme(.dark)
+}

--- a/README.md
+++ b/README.md
@@ -11,26 +11,27 @@ Below are few examples:
 #### Uniform radii on all corners with custom smoothing
 ``` swift
 SmoothRoundedRectangle(radius: 80, smoothness: .custom(100))
-    .fill(Color.cyan)
+    .fill(.cyan)
     .frame(width: 240, height: 240)
 ```
 
 #### Uniform radii on selected corners
 ``` swift
-SmoothRoundedRectangle(radius: 80, corners: [.topLeft, .bottomRight])
-    .fill(Color.green)
+SmoothRoundedRectangle(radius: 80, corners: [.topLeading, .bottomTrailing])
+    .fill(.green)
     .frame(width: 240, height: 80)
 ```
 
 #### Different radii on different corners
 ``` swift
 SmoothRoundedRectangle(
-    topLeft: 80,
-    topRight: 20,
-    bottomRight: 80,
-    bottomLeft: 20,
-    smoothness: .iOS)
-    .frame(width: 240, height: 120)
+    topLeadingRadius: 80,
+    bottomLeadingRadius: 80,
+    bottomTrailingRadius: 20,
+    topTrailingRadius: 20,
+    smoothness: .iOS
+)
+.frame(width: 240, height: 120)
 ```
 
 ### Using inside clipShape

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -22,26 +22,25 @@ public struct SmoothRoundedRectangle: InsettableShape {
     
     /// Standard all corners with optional smoothness and same radius
     public init(radius: CGFloat, smoothness: Smoothness = .none) {
-        self.init(topLeading: radius, topTrailing: radius, bottomTrailing: radius, bottomLeading: radius, smoothness: smoothness)
+        self.init(topLeading: radius, bottomLeading: radius, bottomTrailing: radius, topTrailing: radius, smoothness: smoothness)
     }
     
     /// Some corners with optional smoothness and same radius
     public init(radius: CGFloat, corners: Corners, smoothness: Smoothness = .none) {
         self.init(
             topLeading: corners.contains(.topLeading) ? radius : 0,
-            topTrailing: corners.contains(.topTrailing) ? radius : 0,
-            bottomTrailing: corners.contains(.bottomTrailing) ? radius : 0,
             bottomLeading: corners.contains(.bottomLeading) ? radius : 0,
+            bottomTrailing: corners.contains(.bottomTrailing) ? radius : 0,
+            topTrailing: corners.contains(.topTrailing) ? radius : 0,
             smoothness: smoothness
         )
     }
-    
     /// Different corners with different radii and smoothing
     public init(
         topLeading: CGFloat,
-        topTrailing: CGFloat,
-        bottomTrailing: CGFloat,
         bottomLeading: CGFloat,
+        bottomTrailing: CGFloat,
+        topTrailing: CGFloat,
         smoothness: Smoothness
     ) {
         let smoothnessValue = smoothness.value

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -22,32 +22,32 @@ public struct SmoothRoundedRectangle: InsettableShape {
     
     /// Standard all corners with optional smoothness and same radius
     public init(radius: CGFloat, smoothness: Smoothness = .none) {
-        self.init(topLeading: radius, bottomLeading: radius, bottomTrailing: radius, topTrailing: radius, smoothness: smoothness)
+        self.init(topLeadingRadius: radius, bottomLeadingRadius: radius, bottomTrailingRadius: radius, topTrailingRadius: radius, smoothness: smoothness)
     }
     
     /// Some corners with optional smoothness and same radius
     public init(radius: CGFloat, corners: Corners, smoothness: Smoothness = .none) {
         self.init(
-            topLeading: corners.contains(.topLeading) ? radius : 0,
-            bottomLeading: corners.contains(.bottomLeading) ? radius : 0,
-            bottomTrailing: corners.contains(.bottomTrailing) ? radius : 0,
-            topTrailing: corners.contains(.topTrailing) ? radius : 0,
+            topLeadingRadius: corners.contains(.topLeading) ? radius : 0,
+            bottomLeadingRadius: corners.contains(.bottomLeading) ? radius : 0,
+            bottomTrailingRadius: corners.contains(.bottomTrailing) ? radius : 0,
+            topTrailingRadius: corners.contains(.topTrailing) ? radius : 0,
             smoothness: smoothness
         )
     }
     /// Different corners with different radii and smoothing
     public init(
-        topLeading: CGFloat,
-        bottomLeading: CGFloat,
-        bottomTrailing: CGFloat,
-        topTrailing: CGFloat,
+        topLeadingRadius: CGFloat = 0,
+        bottomLeadingRadius: CGFloat = 0,
+        bottomTrailingRadius: CGFloat = 0,
+        topTrailingRadius: CGFloat = 0,
         smoothness: Smoothness
     ) {
         let smoothnessValue = smoothness.value
-        self.topLeftCorner = CornerAttributes(radius: getLTRCorner(topLeading, topTrailing), smoothness: smoothnessValue)
-        self.topRightCorner = CornerAttributes(radius: getLTRCorner(topTrailing, topLeading), smoothness: smoothnessValue)
-        self.bottomLeftCorner = CornerAttributes(radius: getLTRCorner(bottomLeading, bottomTrailing), smoothness: smoothnessValue)
-        self.bottomRightCorner = CornerAttributes(radius: getLTRCorner(bottomTrailing, bottomLeading), smoothness: smoothnessValue)
+        self.topLeftCorner = CornerAttributes(radius: getLTRCorner(topLeadingRadius, topTrailingRadius), smoothness: smoothnessValue)
+        self.topRightCorner = CornerAttributes(radius: getLTRCorner(topTrailingRadius, topLeadingRadius), smoothness: smoothnessValue)
+        self.bottomLeftCorner = CornerAttributes(radius: getLTRCorner(bottomLeadingRadius, bottomTrailingRadius), smoothness: smoothnessValue)
+        self.bottomRightCorner = CornerAttributes(radius: getLTRCorner(bottomTrailingRadius, bottomLeadingRadius), smoothness: smoothnessValue)
     }
     
     private func getLTRCorner(_ a: CGFloat, _ b: CGFloat) ->  CGFloat {


### PR DESCRIPTION
I have added a preview to show case this new change. 

<img width="512" alt="426606858-9bb3c595-a06d-4183-bf10-2a504f6cef4d" src="https://github.com/user-attachments/assets/9ae3c203-a628-40fc-b416-a5c022ee5820" />

Also, I've renamed the arguments to make it look more similar with the native `UnevenRoundedRectangle` API. The only unmatched property would be the `smoothness` argument. 

How about renaming that to `style` with the default value of `.smooth(100)`? 

The values could be like:
```
case circular // 0
case continuous // iOS default: 60
case smooth(_: CGFloat) // Custom factor between 0 and 100

static var smooth: Self { .smooth(100) }
```

We can even make it more consistent with the rest of the native API by making the smoothness accept `0` to `1` instead of `0` to `100`

Let me know what you think 🙌🏻