### PR TITLE
Style argument

### DIFF
--- a/Demo/Demo/CircularCurveComparisonView.swift
+++ b/Demo/Demo/CircularCurveComparisonView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import SmoothRoundedRectangle
+
+struct CircularCurveComparisonView: View {
+	@State var radius: Double = 8
+	@State var smoothness: Double = 1
+
+	let sizes: [CGFloat] = [16, 32, 48, 64, 128, 256]
+
+	var body: some View {
+		VStack(spacing: 8) {
+			ForEach(sizes, id: \.self) { size in
+
+				ZStack {
+					RoundedRectangle(cornerRadius: radius, style: .continuous)
+						.foregroundStyle(.red)
+
+					SmoothRoundedRectangle(
+						radius: radius,
+						style: .smooth(smoothness)
+					)
+					.foregroundStyle(.indigo)
+				}
+				.frame(width: size, height: size)
+			}
+
+			VStack(alignment: .leading, spacing: 0) {
+				HStack {
+					Text("Radius")
+					Spacer()
+					Text(radius, format: .number.precision(.fractionLength(0)))
+						.monospacedDigit()
+				}
+				Slider(value: $radius, in: 0...sizes.last!)
+
+				Divider().frame(height: 64)
+
+				HStack {
+					Text("Smoothness")
+					Spacer()
+					Text(smoothness, format: .number.precision(.fractionLength(2)))
+						.monospacedDigit()
+				}
+				Slider(value: $smoothness, in: 0...1)
+			}
+		}
+		.padding()
+		.preferredColorScheme(.dark)
+	}
+}
+
+#Preview {
+	CircularCurveComparisonView()
+}

--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -3,7 +3,7 @@ import SmoothRoundedRectangle
 
 struct ContentView: View {
 	@State var radius: Double = 128
-	@State var smoothness: Double = 100
+	@State var smoothness: Double = 1
 
 	var body: some View {
 		VStack(spacing: 64) {
@@ -34,10 +34,10 @@ struct ContentView: View {
 				HStack {
 					Text("Smoothness")
 					Spacer()
-					Text(smoothness, format: .number.precision(.fractionLength(0)))
+					Text(smoothness, format: .number.precision(.fractionLength(2)))
 						.monospacedDigit()
 				}
-				Slider(value: $smoothness, in: 0...100)
+				Slider(value: $smoothness, in: 0...1)
 			}
 		}
 		.padding()

--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
 
 				SmoothRoundedRectangle(
 					radius: radius,
-					smoothness: .custom(smoothness)
+					style: .smooth(smoothness)
 				)
 				.foregroundStyle(.indigo)
 			}

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -19,7 +19,7 @@ import SmoothRoundedRectangle
 		bottomLeadingRadius: 0,
 		bottomTrailingRadius: radius,
 		topTrailingRadius: radius,
-		smoothness: .custom(100)
+		style: .smooth(100)
 	)
 
 	VStack {

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -4,7 +4,7 @@ import SmoothRoundedRectangle
 @available(iOS 16, *)
 #Preview {
 	@Previewable @State var radius: Double = 64
-	@Previewable @State var smoothness: Double = 50
+	@Previewable @State var smoothness: Double = 1
 
 	let unevenShape = UnevenRoundedRectangle(
 		topLeadingRadius: 0,
@@ -19,7 +19,7 @@ import SmoothRoundedRectangle
 		bottomLeadingRadius: 0,
 		bottomTrailingRadius: radius,
 		topTrailingRadius: radius,
-		style: .smooth(100)
+		style: .smooth(smoothness)
 	)
 
 	VStack {
@@ -50,10 +50,10 @@ import SmoothRoundedRectangle
 			HStack {
 				Text("Smoothness")
 				Spacer()
-				Text(smoothness, format: .number.precision(.fractionLength(0)))
+				Text(smoothness, format: .number.precision(.fractionLength(2)))
 					.monospacedDigit()
 			}
-			Slider(value: $smoothness, in: 0...50)
+			Slider(value: $smoothness, in: 0...1)
 		}
 	}
 	.padding()

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ ContentView()
     .clipShape(SmoothRoundedRectangle(radius: 12, style: .continues))
 ```
 ## Results and comparison
-#### A comparison of zero smoothness and 60%. <br>
-The indigo corner has 60% smoothing and the green one has no smoothing. <br>
+#### A comparison of zero smoothness and 70%. <br>
+The indigo corner has 70% smoothing and the green one has no smoothing. <br>
 ![Group 7](https://github.com/user-attachments/assets/0390b622-a23f-42a9-a19f-0b12a059e6bb)
 
 #### A comparison of different smoothnesses and comparison with Figma's smoothness. <br>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Article: [Parametric corner smoothing in SwiftUI](https://medium.com/@zvyom/para
 Below are few examples:
 #### Uniform radii on all corners with custom smoothing
 ``` swift
-SmoothRoundedRectangle(radius: 80, smoothness: .custom(100))
+SmoothRoundedRectangle(radius: 80, style: .smooth(100))
     .fill(.cyan)
     .frame(width: 240, height: 240)
 ```
@@ -29,7 +29,7 @@ SmoothRoundedRectangle(
     bottomLeadingRadius: 80,
     bottomTrailingRadius: 20,
     topTrailingRadius: 20,
-    smoothness: .iOS
+    style: .continues
 )
 .frame(width: 240, height: 120)
 ```
@@ -37,7 +37,7 @@ SmoothRoundedRectangle(
 ### Using inside clipShape
 ``` swift
 ContentView()
-    .clipShape(SmoothRoundedRectangle(radius: 12, smoothness: .iOS))
+    .clipShape(SmoothRoundedRectangle(radius: 12, style: .continues))
 ```
 ## Results and comparison
 #### A comparison of zero smoothness and 60%. <br>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmoothRoundedRectangle <br> [![license](https://badgen.net/badge/license/MIT/green?icon=github)](./LICENSE) [![language](https://badgen.net/badge/language/Swift/orange?icon=apple)](./LANGUAGE)
 
 ## Overview
-A custom SwiftUI shape which mimics Figma's smooth corner rounding for rectangles. The smoothness value can be anyting between 0 to 1, 0 with completely circular corner radius and 1 with full smoothness. Corners to which rounding has to be applied can be specified as well. The amount of rounding can be even more than half of the smaller dimension of rectangle just like in Figma.
+A custom SwiftUI shape which mimics Figma's smooth corner rounding for rectangles. The smoothness value can be anything between 0 to 1, 0 with completely circular corner radius and 1 with full smoothness. Corners to which rounding has to be applied can be specified as well. The amount of rounding can be even more than half of the smaller dimension of rectangle just like in Figma.
 
 ### Detail explanation
 Article: [Parametric corner smoothing in SwiftUI](https://medium.com/@zvyom/parametric-corner-smoothing-in-swiftui-108acea52874)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmoothRoundedRectangle <br> [![license](https://badgen.net/badge/license/MIT/green?icon=github)](./LICENSE) [![language](https://badgen.net/badge/language/Swift/orange?icon=apple)](./LANGUAGE)
 
 ## Overview
-A custom SwiftUI shape which mimics Figma's smooth corner rounding for rectangles. The smoothness value can be anyting between 0 to 100, 0 with completely circular corner radius and 100 with full smoothness. Corners to which rounding has to be applied can be specified as well. The amount of rounding can be even more than half of the smaller dimension of rectangle just like in Figma.
+A custom SwiftUI shape which mimics Figma's smooth corner rounding for rectangles. The smoothness value can be anyting between 0 to 1, 0 with completely circular corner radius and 1 with full smoothness. Corners to which rounding has to be applied can be specified as well. The amount of rounding can be even more than half of the smaller dimension of rectangle just like in Figma.
 
 ### Detail explanation
 Article: [Parametric corner smoothing in SwiftUI](https://medium.com/@zvyom/parametric-corner-smoothing-in-swiftui-108acea52874)
@@ -10,7 +10,7 @@ Article: [Parametric corner smoothing in SwiftUI](https://medium.com/@zvyom/para
 Below are few examples:
 #### Uniform radii on all corners with custom smoothing
 ``` swift
-SmoothRoundedRectangle(radius: 80, style: .smooth(100))
+SmoothRoundedRectangle(radius: 80, style: .smooth(1))
     .fill(.cyan)
     .frame(width: 240, height: 240)
 ```

--- a/src/SmoothRoundedRectangle+Attributes.swift
+++ b/src/SmoothRoundedRectangle+Attributes.swift
@@ -12,10 +12,10 @@ public extension SmoothRoundedRectangle {
     /// Smoothing factor for corner radius
     enum Style {
         case circular // 0
-        case continuous // iOS default: 60
-        case smooth(_: CGFloat) // Custom factor between 0 and 100
-        
-        public static var smooth: Self { .smooth(100) }
+        case continuous // iOS default: 0.6
+        case smooth(_: Double) // Custom factor between 0 and 1
+
+        public static var smooth: Self { .smooth(1) }
     }
     
     struct Corners: OptionSet, Sendable {

--- a/src/SmoothRoundedRectangle+Attributes.swift
+++ b/src/SmoothRoundedRectangle+Attributes.swift
@@ -12,7 +12,7 @@ public extension SmoothRoundedRectangle {
     /// Smoothing factor for corner radius
     enum Style {
         case circular // 0
-        case continuous // iOS default: 0.6
+        case continuous // iOS default: 0.7
         case smooth(_: Double) // Custom factor between 0 and 1
 
         public static var smooth: Self { .smooth(1) }

--- a/src/SmoothRoundedRectangle+Attributes.swift
+++ b/src/SmoothRoundedRectangle+Attributes.swift
@@ -10,10 +10,10 @@ import Foundation
 public extension SmoothRoundedRectangle {
     
     /// Smoothing factor for corner radius
-    enum Smoothness {
-        case none   // 0
-        case iOS    // 60
-        case custom(_: CGFloat) // Custom factor between 0 and 100
+    enum Style {
+        case circular // 0
+        case continuous // iOS default: 60
+        case smooth(_: CGFloat) // Custom factor between 0 and 100
     }
     
     struct Corners: OptionSet, Sendable {

--- a/src/SmoothRoundedRectangle+Attributes.swift
+++ b/src/SmoothRoundedRectangle+Attributes.swift
@@ -14,6 +14,8 @@ public extension SmoothRoundedRectangle {
         case circular // 0
         case continuous // iOS default: 60
         case smooth(_: CGFloat) // Custom factor between 0 and 100
+        
+        public static var smooth: Self { .smooth(100) }
     }
     
     struct Corners: OptionSet, Sendable {

--- a/src/SmoothRoundedRectangle+Helper.swift
+++ b/src/SmoothRoundedRectangle+Helper.swift
@@ -237,7 +237,7 @@ extension SmoothRoundedRectangle.Style {
         case .continuous:
             return 0.6
         case .smooth(let value):
-            return value / 100.0
+            return value
         }
     }
 }

--- a/src/SmoothRoundedRectangle+Helper.swift
+++ b/src/SmoothRoundedRectangle+Helper.swift
@@ -235,7 +235,7 @@ extension SmoothRoundedRectangle.Style {
         case .circular:
             return 0
         case .continuous:
-            return 0.6
+            return 0.7
         case .smooth(let value):
             return value
         }

--- a/src/SmoothRoundedRectangle+Helper.swift
+++ b/src/SmoothRoundedRectangle+Helper.swift
@@ -229,14 +229,14 @@ extension SmoothRoundedRectangle {
     }
 }
 
-extension SmoothRoundedRectangle.Smoothness {
+extension SmoothRoundedRectangle.Style {
     var value: CGFloat {
         switch self {
-        case .none:
+        case .circular:
             return 0
-        case .iOS:
+        case .continuous:
             return 0.6
-        case .custom(let value):
+        case .smooth(let value):
             return value / 100.0
         }
     }

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -21,12 +21,12 @@ public struct SmoothRoundedRectangle: InsettableShape {
     // MARK: - Initializers
     
     /// Standard all corners with optional smoothness and same radius
-    public init(radius: CGFloat, style: Style = .circular) {
+    public init(radius: CGFloat, style: Style = .smooth) {
         self.init(topLeadingRadius: radius, bottomLeadingRadius: radius, bottomTrailingRadius: radius, topTrailingRadius: radius, style: style)
     }
     
     /// Some corners with optional smoothness and same radius
-    public init(radius: CGFloat, corners: Corners, style: Style = .circular) {
+    public init(radius: CGFloat, corners: Corners, style: Style = .smooth) {
         self.init(
             topLeadingRadius: corners.contains(.topLeading) ? radius : 0,
             bottomLeadingRadius: corners.contains(.bottomLeading) ? radius : 0,

--- a/src/SmoothRoundedRectangle.swift
+++ b/src/SmoothRoundedRectangle.swift
@@ -21,18 +21,18 @@ public struct SmoothRoundedRectangle: InsettableShape {
     // MARK: - Initializers
     
     /// Standard all corners with optional smoothness and same radius
-    public init(radius: CGFloat, smoothness: Smoothness = .none) {
-        self.init(topLeadingRadius: radius, bottomLeadingRadius: radius, bottomTrailingRadius: radius, topTrailingRadius: radius, smoothness: smoothness)
+    public init(radius: CGFloat, style: Style = .circular) {
+        self.init(topLeadingRadius: radius, bottomLeadingRadius: radius, bottomTrailingRadius: radius, topTrailingRadius: radius, style: style)
     }
     
     /// Some corners with optional smoothness and same radius
-    public init(radius: CGFloat, corners: Corners, smoothness: Smoothness = .none) {
+    public init(radius: CGFloat, corners: Corners, style: Style = .circular) {
         self.init(
             topLeadingRadius: corners.contains(.topLeading) ? radius : 0,
             bottomLeadingRadius: corners.contains(.bottomLeading) ? radius : 0,
             bottomTrailingRadius: corners.contains(.bottomTrailing) ? radius : 0,
             topTrailingRadius: corners.contains(.topTrailing) ? radius : 0,
-            smoothness: smoothness
+            style: style
         )
     }
     /// Different corners with different radii and smoothing
@@ -41,9 +41,9 @@ public struct SmoothRoundedRectangle: InsettableShape {
         bottomLeadingRadius: CGFloat = 0,
         bottomTrailingRadius: CGFloat = 0,
         topTrailingRadius: CGFloat = 0,
-        smoothness: Smoothness
+        style: Style
     ) {
-        let smoothnessValue = smoothness.value
+        let smoothnessValue = style.value
         self.topLeftCorner = CornerAttributes(radius: getLTRCorner(topLeadingRadius, topTrailingRadius), smoothness: smoothnessValue)
         self.topRightCorner = CornerAttributes(radius: getLTRCorner(topTrailingRadius, topLeadingRadius), smoothness: smoothnessValue)
         self.bottomLeftCorner = CornerAttributes(radius: getLTRCorner(bottomLeadingRadius, bottomTrailingRadius), smoothness: smoothnessValue)


### PR DESCRIPTION
Change the `smoothness` argument label to `style` to make it more consistent with the SwiftUI native API.
Change the bounding range from `0...100` to `0...1` to make it more consistent with the iOS native API.
Change the circular value from `0.6` to `0.7` to make it more like the original one.
Add a demo playground to represent the new changes.