### PR TITLE
feat: extend minimum supporting os version

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
@@ -203,7 +203,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;

--- a/Demo/Demo/LayoutDirectedPreview.swift
+++ b/Demo/Demo/LayoutDirectedPreview.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 import SmoothRoundedRectangle
 
-@available(iOS 16, *)
+@available(iOS 16, *) // UnevenRoundedRectangle
+@available(iOS 17, *) // @Previewable
 #Preview {
 	@Previewable @State var radius: Double = 64
 	@Previewable @State var smoothness: Double = 1

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
     name: "SmoothRoundedRectangle",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v15),
+        .iOS(.v13),
+        .macOS(.v10_15),
         .tvOS(.v13),
         .watchOS(.v6),
     ],


### PR DESCRIPTION
Extend minimum supporting os version:
- iOS: from `v16` down to `v13`
- macOS: from `v15` down to `v10_15`