### PR TITLE
Fix smoothness out of bound

### DIFF
--- a/Demo/Demo/InsetPreview.swift
+++ b/Demo/Demo/InsetPreview.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import SmoothRoundedRectangle
+
+@available(iOS 17, *) // @Previewable
+#Preview {
+	@Previewable @State var radius: Double = 64
+	@Previewable @State var smoothness: Double = -10
+
+	let smoothUnevenShape = SmoothRoundedRectangle(
+		radius: radius,
+		style: .smooth(smoothness)
+	)
+
+	VStack {
+		smoothUnevenShape
+			.strokeBorder(lineWidth: 4)
+			.foregroundStyle(.indigo)
+			.aspectRatio(contentMode: .fit)
+			.frame(maxHeight: .infinity)
+
+		VStack(alignment: .leading, spacing: 0) {
+			HStack {
+				Text("Radius")
+				Spacer()
+				Text(radius, format: .number.precision(.fractionLength(0)))
+					.monospacedDigit()
+			}
+			Slider(value: $radius, in: 0...128)
+
+			Divider().frame(height: 64)
+
+			HStack {
+				Text("Smoothness")
+				Spacer()
+				Text(smoothness, format: .number.precision(.fractionLength(2)))
+					.monospacedDigit()
+			}
+			Slider(value: $smoothness, in: -10...10)
+		}
+	}
+	.padding()
+	.preferredColorScheme(.dark)
+}

--- a/src/SmoothRoundedRectangle+Attributes.swift
+++ b/src/SmoothRoundedRectangle+Attributes.swift
@@ -11,10 +11,18 @@ public extension SmoothRoundedRectangle {
     
     /// Smoothing factor for corner radius
     enum Style {
-        case circular // 0
-        case continuous // iOS default: 0.7
-        case smooth(_: Double) // Custom factor between 0 and 1
+        ///  No smoothing applied.
+        ///  - Same as calling `smooth(0)`
+        case circular
+        /// iOS default smoothness.
+        /// - Same as calling `smooth(0.7)`
+        case continuous
+        /// Custom factor between `0` and `1`, represented as a `Double`.
+        /// - Note: Values outside the valid range will be clamped to the nearest bound.
+        case smooth(_: Double)
 
+        /// Maximum valid smoothness.
+        /// - Same as calling `smooth(1)`
         public static var smooth: Self { .smooth(1) }
     }
     

--- a/src/SmoothRoundedRectangle+Helper.swift
+++ b/src/SmoothRoundedRectangle+Helper.swift
@@ -237,8 +237,8 @@ extension SmoothRoundedRectangle.Style {
         case .continuous:
             return 0.7
         case .smooth(let value):
-            // Clamp the value between 0 and 1
-            return max(min(value, 1), 0)
+            let validRange = 0...1.0
+            return max(min(value, validRange.upperBound), validRange.lowerBound)
         }
     }
 }

--- a/src/SmoothRoundedRectangle+Helper.swift
+++ b/src/SmoothRoundedRectangle+Helper.swift
@@ -237,7 +237,8 @@ extension SmoothRoundedRectangle.Style {
         case .continuous:
             return 0.7
         case .smooth(let value):
-            return value
+            // Clamp the value between 0 and 1
+            return max(min(value, 1), 0)
         }
     }
 }


### PR DESCRIPTION
The original code had a bug that shows itself when passing an invalid smoothness value:

Take a look at this example where the value is below `0` (around 3.5 in this case):
<img width="366" alt="Screenshot 2025-05-13 at 10 26 34 AM" src="https://github.com/user-attachments/assets/23ec9290-ed27-4497-b156-af9284d5de5c" />

Take a look at this example where the value is above `1`:
<img width="393" alt="Screenshot 2025-05-13 at 10 26 41 AM" src="https://github.com/user-attachments/assets/ab4c3de6-1fee-438b-bd1b-bdede0d64b68" />

So firstly, I have added another preview to represent this issue and then fix it by clamping the value in the range of `0` to `1` to prevent undesired behavior.

I have also added a simple documentation for each case.